### PR TITLE
Feature/client side download

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
+![FetchDock Logo](./pwa/public/logo-v1-full.svg)
+> **In active development** — features and APIs may change without notice.
+
 # FetchDock Server
-## WIP - Do not use in production!
 
 ## Description
 
@@ -16,13 +18,10 @@ More to be added in the future.
 
 ## Companion Extensions
 
-I'm working on a companion (browser) extension for this API.
-This extension allows you to interact with the API directly from your browser,
-making it easier to manage the downloads and send links to the API.
+[FetchDock Extension](https://github.com/fetchdock/fetchdock-extension) has been released and is available for Firefox and Chrome.
+This extension is actively developed and targeted when working on this project.
 
-It will be released for Firefox and Chrome soon.
-
-At the time of writing this, the extension is still in development and not yet published to the browser stores.
+The extension and server follows the same MAJOR and MINOR version numbering to indicate compatibility.
 
 ## Authentication
 
@@ -56,7 +55,7 @@ If you're having issues with setting up authentication with your provider, feel 
 - [ ] Add monitoring and logging features (partially done)
 - [ ] Implement rate limiting to prevent abuse
 - [ ] Implement a frontend for easier interaction with the API
-  - [ ] [FetchDock Browser Extension](https://github.com/FetchDock/fetchdock-extension) - (in active development)
+  - [x] [FetchDock Browser Extension](https://github.com/FetchDock/fetchdock-extension) - (in active development)
   - [ ] Web UI dashboard - (in active development)
   - [ ] Desktop app
   - [ ] Mobile app
@@ -68,6 +67,15 @@ If you're having issues with setting up authentication with your provider, feel 
 
 
 ## Footnotes
+
+### Working with sensitive data (e.g. cookies)
+
+The server supports storing cookies in the database.
+This is useful for download jobs that require authentication, ie: resources requiring a login.
+To provide this feature it is necessary to store the cookie somewhere until the job is completed.
+
+The cookies are never shared with any third party, send to any client or stored in any log.
+The cookies are also permanently deleted after the job is completed.
 
 ### Usage of AI assisted code generation
 

--- a/api/config/packages/security.yaml
+++ b/api/config/packages/security.yaml
@@ -52,6 +52,7 @@ security:
         - { path: ^/docs, roles: PUBLIC_ACCESS } # Allows accessing the Swagger UI docs
         - { path: ^/contexts, roles: PUBLIC_ACCESS } # Allows accessing the Swagger UI contexts
         - { path: ^/versions, roles: PUBLIC_ACCESS } # Allows accessing the versions endpoint
+        - { path: ^/download/, roles: PUBLIC_ACCESS } # Allows accessing the download endpoint
         - { path: ^/, roles: IS_AUTHENTICATED_FULLY }
         # - { path: ^/admin, roles: ROLE_ADMIN }
         # - { path: ^/profile, roles: ROLE_USER }

--- a/pwa/public/logo-icon.svg
+++ b/pwa/public/logo-icon.svg
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="256"
+   height="256"
+   viewBox="0 0 256 256"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="logo-chatgpt-for-inkscape.svg"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   inkscape:export-filename="logo-draft-v1.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview4"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="4.5273438"
+     inkscape:cx="127.88956"
+     inkscape:cy="21.977567"
+     inkscape:window-width="2560"
+     inkscape:window-height="1368"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4" />
+  <defs
+     id="defs2">
+    <linearGradient
+       id="grad1"
+       x1="0%"
+       y1="0%"
+       x2="100%"
+       y2="100%">
+      <stop
+         offset="0%"
+         stop-color="#4FC3F7"
+         id="stop1" />
+      <stop
+         offset="100%"
+         stop-color="#1565C0"
+         id="stop2" />
+    </linearGradient>
+  </defs>
+  <!-- Map Pin -->
+  <path
+     d="M128 20C80 20 48 52 48 96c0 52 80 140 80 140s80-88 80-140c0-44-32-76-80-76z"
+     fill="url(#grad1)"
+     id="path2" />
+  <!-- Inner circle -->
+  <path
+     fill="#ffffff"
+     id="circle2"
+     sodipodi:type="arc"
+     sodipodi:cx="128"
+     sodipodi:cy="96"
+     sodipodi:rx="54.798965"
+     sodipodi:ry="54.798965"
+     sodipodi:start="0"
+     sodipodi:end="6.2793699"
+     sodipodi:arc-type="slice"
+     d="M 182.79897,96 A 54.798965,54.798965 0 0 1 128.05227,150.79894 54.798965,54.798965 0 0 1 73.201134,96.10454 54.798965,54.798965 0 0 1 127.84319,41.201259 54.798965,54.798965 0 0 1 182.79857,95.79092 L 128,96 Z" />
+  <!-- Download arrow -->
+  <path
+     d="m 128,59.397757 v 61.204483 m 0,0 -24.48179,-24.481791 M 128,120.60224 152.48179,96.120449"
+     stroke="#1565c0"
+     stroke-width="8"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     fill="none"
+     id="path3" />
+  <!-- Waves -->
+</svg>

--- a/pwa/public/logo-v1-full.svg
+++ b/pwa/public/logo-v1-full.svg
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="750"
+   height="256"
+   viewBox="0 0 750 256"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="logo-v1-full.svg"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   inkscape:export-filename="logo-draft-v1.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview4"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="2"
+     inkscape:cx="337.75"
+     inkscape:cy="111.75"
+     inkscape:window-width="2560"
+     inkscape:window-height="1412"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4"
+     showguides="true">
+    <sodipodi:guide
+       position="128.16797,20.003906"
+       orientation="0,-1"
+       id="guide4"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="128.5625,131.39844"
+       orientation="0,-1"
+       id="guide5"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="128.17593,105.19832"
+       orientation="0,-1"
+       id="guide6"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <defs
+     id="defs2">
+    <linearGradient
+       id="linearGradient2"
+       inkscape:collect="always">
+      <stop
+         style="stop-color:#247dce;stop-opacity:1;"
+         offset="0"
+         id="stop3" />
+      <stop
+         style="stop-color:#49b8f1;stop-opacity:0.49411765;"
+         offset="1"
+         id="stop4" />
+    </linearGradient>
+    <linearGradient
+       id="grad1"
+       x1="55.770962"
+       y1="17.213259"
+       x2="241.67416"
+       y2="203.11646"
+       gradientTransform="scale(0.86066297,1.161895)"
+       gradientUnits="userSpaceOnUse">
+      <stop
+         offset="0%"
+         stop-color="#4FC3F7"
+         id="stop1" />
+      <stop
+         offset="100%"
+         stop-color="#1565C0"
+         id="stop2" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2"
+       id="linearGradient4"
+       x1="235.58041"
+       y1="162.04498"
+       x2="873.57831"
+       y2="162.04498"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-39.686336,22.175487)" />
+  </defs>
+  <!-- Map Pin -->
+  <path
+     d="m 128,20 c -48,0 -80,32 -80,76 0,52 80,140 80,140 0,0 80,-88 80,-140 0,-44 -32,-76 -80,-76 z"
+     fill="url(#grad1)"
+     id="path2"
+     style="fill:url(#grad1)" />
+  <!-- Inner circle -->
+  <path
+     fill="#ffffff"
+     id="circle2"
+     sodipodi:type="arc"
+     sodipodi:cx="128"
+     sodipodi:cy="96"
+     sodipodi:rx="54.798965"
+     sodipodi:ry="54.798965"
+     sodipodi:start="0"
+     sodipodi:end="6.2793699"
+     sodipodi:arc-type="slice"
+     d="M 182.79897,96 A 54.798965,54.798965 0 0 1 128.05227,150.79894 54.798965,54.798965 0 0 1 73.201134,96.10454 54.798965,54.798965 0 0 1 127.84319,41.201259 54.798965,54.798965 0 0 1 182.79857,95.79092 L 128,96 Z" />
+  <!-- Download arrow -->
+  <path
+     d="m 128,59.397757 v 61.204483 m 0,0 -24.48179,-24.481791 M 128,120.60224 152.48179,96.120449"
+     stroke="#1565c0"
+     stroke-width="8"
+     stroke-linecap="round"
+     stroke-linejoin="round"
+     fill="none"
+     id="path3" />
+  <!-- Waves -->
+  <text
+     xml:space="preserve"
+     style="font-size:133.333px;text-align:start;letter-spacing:-10px;writing-mode:lr-tb;direction:ltr;text-anchor:start;fill:url(#linearGradient4)"
+     x="182.96077"
+     y="234.22035"
+     id="text1"><tspan
+       sodipodi:role="line"
+       id="tspan1"
+       x="182.96077"
+       y="234.22035"
+       style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:133.333px;font-family:'Noto Sans';-inkscape-font-specification:'Noto Sans';letter-spacing:-10px;fill:url(#linearGradient4);fill-opacity:1">FetchDock</tspan></text>
+</svg>


### PR DESCRIPTION
This PR allows the extension to just open the downloaded files' downloadUri in a popup without having to mess with headers (jwt-token).

Since the downloadUri contains a randomly generated token (inherited from download job) there's no need for token, as a side effect this also allows the user to share the link to other people should they want

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] I have read the **CONTRIBUTING** document.
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
